### PR TITLE
Removed Kimono Labs as the service is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@
 > Based in DDD (Domain Driven Development). Generates automatically API's in different languages.
 
 * [RAML, RESTful API Modeling Language](http://raml.org).
-* [kimono, generate API from websites](https://www.kimonolabs.com).
 * [import.io, turn web pages into Data](https://import.io/).
 * [swagger.io](http://swagger.io).
 * [Runscope](https://www.runscope.com/) - Automated API Monitoring & Testing.


### PR DESCRIPTION
Kimono Labs public API will be terminated as of 2016-02-29 as stated [here](http://blog.kimonolabs.com/2016/02/15/the-kimono-team-is-joining-palantir/)