### PR TITLE
Include FastAPI in frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@
 
 * [Loopback](http://loopback.io).
 * [Sails.js](http://sailsjs.org).
+* [FastAPI](https://github.com/tiangolo/fastapi) - A modern, fast (high-performance), web framework for building APIs with Python 3.6+ based on standard Python type hints. With automatic API documentation using Swagger UI and ReDoc, based on OpenAPI and JSON Schema.
 
 ## Gateways
 


### PR DESCRIPTION
[FastAPI](https://github.com/tiangolo/fastapi) - A modern, fast (high-performance), web framework for building APIs with Python 3.6+ based on standard Python type hints. With automatic API documentation using Swagger UI and ReDoc, based on OpenAPI and JSON Schema.