### PR TITLE
Add FakeQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 * [json-server](https://github.com/typicode/json-server) – Get a full fake REST API with zero coding in less than 30 seconds.
 * [Mocky.io](http://www.mocky.io/) – Free online service to create fake HTTP responses.
 * [Swagger API Mock](https://github.com/bulkismaslom/swagger-api-mock) – Mock RESTful API based on swagger schema
+* [FakeQL](https://fakeql.com/) – Mainly focused on GraphQL, but can mock RESTful APIs, as well.
 
 ### Response
 


### PR DESCRIPTION
Mainly focused on mocking GraphQL APIs, but can mock RESTful APIs, as well.