### PR TITLE
Add Agent Gateway to Open Source / Self-hosted gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,11 @@
 
 ### Open Source / Self-hosted
 
+* [Agent Gateway](https://ozorown.github.io) — 40+ API services (geolocation, crypto, DNS, screenshots, scraping) behind a single gateway with built-in auth, rate limiting, and credit-based billing.
 * [API Umbrella](http://apiumbrella.io/).
 * [ApiAxle](http://apiaxle.com).
 * [KrakenD](http://krakend.io).
 * [Mashape Kong](https://getkong.org/).
 * [Tyk](https://tyk.io/).
 * [WSO2 API Manager](http://wso2.com/api-management/try-it/).
+


### PR DESCRIPTION
## Summary

Adding [Agent Gateway](https://ozorown.github.io) to the **Open Source / Self-hosted** section under **Gateways**.

Agent Gateway is a self-hostable API gateway that aggregates 40+ API services (geolocation, crypto prices, DNS lookups, screenshots, web scraping, and more) behind a single endpoint with:

- Built-in API key authentication
- Per-key rate limiting
- Credit-based billing system
- Single integration point for multiple services

Placed alphabetically before API Umbrella.