### PR TITLE
Add MockServer to Mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
 * [FakeRest](https://github.com/marmelab/FakeRest) – Patch XMLHttpRequest to fake a REST API client-side.
 * [JSON Placeholder](http://jsonplaceholder.typicode.com/) – Free online REST service that you can use whenever you need some fake data.
 * [json-server](https://github.com/typicode/json-server) – Get a full fake REST API with zero coding in less than 30 seconds.
+* [MockServer](https://www.mock-server.com) - Mocking, debugging proxy and chaos engineering for HTTP, gRPC, GraphQL, LLM, MCP, Kafka, TCP and more; mock APIs, record/replay and inspect traffic, verify requests, and inject chaos. Docker, JAR, Helm.
 * [Mocky.io](http://www.mocky.io/) – Free online service to create fake HTTP responses.
 * [FakeQL](https://fakeql.com/) – Mainly focused on GraphQL, but can mock RESTful APIs, as well.
 * [PIPL API](https://pipl.ir) – Free and public API that generates random and fake people's data in JSON


### PR DESCRIPTION
Adds [MockServer](https://www.mock-server.com) to the **Mocking** section.

MockServer is an open-source (Apache-2.0) HTTP(S)/REST/gRPC/LLM mock server and proxy used for integration and chaos testing — mock any dependency, record/replay traffic, verify requests, and inject faults. It runs as a Docker image, JAR, Helm chart, or embedded Java library, with clients for many languages.

- Source: https://github.com/mock-server/mockserver-monorepo
- Homepage/docs: https://www.mock-server.com

Checklist:
- [x] One item added, in the relevant section
- [x] Inserted in alphabetical order
- [x] Follows the list's entry format
- [x] Project is open-source and actively maintained